### PR TITLE
Fix typo

### DIFF
--- a/examples/with-firebase-authentication-serverless/utils/auth/user.js
+++ b/examples/with-firebase-authentication-serverless/utils/auth/user.js
@@ -31,7 +31,7 @@ export const createAuthUser = firebaseUser => {
  * @return {Object|null} AuthUserInfo - The auth user info object.
  * @return {String} AuthUserInfo.AuthUser - An AuthUser object (see
  *   `createAuthUser` above).
- * @return {String} AuthUser.token - The user's encoded Firebase token.
+ * @return {String} AuthUserInfo.token - The user's encoded Firebase token.
  */
 export const createAuthUserInfo = ({
   firebaseUser = null,


### PR DESCRIPTION
@ line 34 - I think this line is referencing the AuthUserInfo.token returned by the `createAuthUserInfo` function, not the AuthUser object, since the AuthUser object doesn't have a token property.